### PR TITLE
Delete 2022-10-01_bcrn22.md

### DIFF
--- a/source/_events/2022-10-01_bcrn22.md
+++ b/source/_events/2022-10-01_bcrn22.md
@@ -1,8 +1,0 @@
----
-title: Barcamp Rhein-Neckar 2022 - Tag 1
-date: 2022-10-01
-location: Dezernat16, Heidelberg
-link: https://barcamp-rhein-neckar.de
-type: unconference
----
-


### PR DESCRIPTION
Barcamp Rhein-Neckar was cancelled today due to missing guests. See Blogpost at https://barcamp-rhein-neckar.de/blog/2022/09/15/barcamp-rhein-neckar-2022-abgesagt/